### PR TITLE
feat(backup): 백업 이력 목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,7 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
-    implementation 'org.springframework.boot:spring-boot-starter-batch'
     testImplementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-api', version: '2.8.4'
-    testImplementation 'org.springframework.batch:spring-batch-test'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
@@ -43,6 +41,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/practice/hrbank/controller/BackupController.java
+++ b/src/main/java/com/practice/hrbank/controller/BackupController.java
@@ -4,7 +4,6 @@ import com.practice.hrbank.dto.backup.BackupDto;
 import com.practice.hrbank.dto.backup.CursorPageResponseBackupDto;
 import com.practice.hrbank.service.BackupService;
 import java.time.Instant;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/backups")
 @RequiredArgsConstructor
 public class BackupController {
+
   private final BackupService backupService;
 
   @GetMapping
@@ -30,21 +30,22 @@ public class BackupController {
       @RequestParam(required = false) Integer size,
       @RequestParam(required = false) String sortField,
       @RequestParam(required = false) String sortDirection
-  ){
-    List<BackupDto> backups = backupService.findAll();
-    return ResponseEntity.ok(null);
+  ) {
+    CursorPageResponseBackupDto response = backupService.findAll(worker, status, startedAtFrom,
+        startedAtTo, idAfter, cursor, size, sortField, sortDirection);
+    return ResponseEntity.ok(response);
   }
 
   @PostMapping
-  public ResponseEntity<BackupDto> create(){
-    BackupDto backup =  backupService.create();
+  public ResponseEntity<BackupDto> create() {
+    BackupDto backup = backupService.create();
     return ResponseEntity.ok(backup);
   }
 
   @GetMapping("/latest")
   public ResponseEntity<BackupDto> getLatest(
       @RequestParam(required = false) String status
-  ){
+  ) {
     BackupDto backup = backupService.findLatest();
     return ResponseEntity.ok(backup);
   }

--- a/src/main/java/com/practice/hrbank/dto/backup/CursorPageResponseBackupDto.java
+++ b/src/main/java/com/practice/hrbank/dto/backup/CursorPageResponseBackupDto.java
@@ -1,7 +1,9 @@
 package com.practice.hrbank.dto.backup;
 
+import org.springframework.data.domain.Page;
+
 public record CursorPageResponseBackupDto(
-//    List<EmployeeDto> content,
+    Page<BackupDto> content,
     String nextCursor,
     Long nextIdAfter,
     Integer size,

--- a/src/main/java/com/practice/hrbank/entity/Backup.java
+++ b/src/main/java/com/practice/hrbank/entity/Backup.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import lombok.Getter;
@@ -32,12 +34,12 @@ public class Backup {
   @Column
   Status status;
 
-//  @OneToOne
-//  @JoinColumn(name = "metadata_id")
-//  Metadata file;
+  @OneToOne
+  @JoinColumn(name = "metadata_id")
+  Metadata file;
 
-  public Backup( Status status, Instant endedAt, Instant startedAt, String worker) {
-//    this.file = file;
+  public Backup(Metadata file, Status status, Instant endedAt, Instant startedAt, String worker) {
+    this.file = file;
     this.status = status;
     this.endedAt = endedAt;
     this.startedAt = startedAt;

--- a/src/main/java/com/practice/hrbank/service/BackupService.java
+++ b/src/main/java/com/practice/hrbank/service/BackupService.java
@@ -1,12 +1,21 @@
 package com.practice.hrbank.service;
 
 import com.practice.hrbank.dto.backup.BackupDto;
+import com.practice.hrbank.dto.backup.CursorPageResponseBackupDto;
 import com.practice.hrbank.entity.Backup;
 import com.practice.hrbank.mapper.BackupMapper;
 import com.practice.hrbank.repository.BackupRepository;
+import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,7 +23,6 @@ import org.springframework.stereotype.Service;
 public class BackupService {
 
   private final BackupRepository backupRepository;
-  private final EmployeeService employeeService;
   private final BackupMapper backupMapper;
 
   public BackupDto create() {
@@ -23,11 +31,33 @@ public class BackupService {
     return backupMapper.toDto(backup);
   }
 
-  public List<BackupDto> findAll() {
-    // TODO : 필터링 로직 추가
-    List<Backup> backups = backupRepository.findAll();
-    return backups.stream().map(backupMapper::toDto).toList();
-  }
+  public CursorPageResponseBackupDto findAll(String worker, String status,
+      Instant startedAtFrom, Instant startedAtTo, Long idAfter, String cursor,
+      Integer size, String sortField, String sortDirection) {
+
+    idAfter = decodeCursor(cursor);
+
+    Specification<Backup> spec = Specification.where(getSpec(worker, status, startedAtFrom, startedAtTo, idAfter));
+    Pageable pageable = createPageable(size, sortField, sortDirection);
+    Page<Backup> backups = backupRepository.findAll(spec, pageable);
+
+    Long nextIdAfter = null;
+    String nextCursor = null;
+
+    if (backups.hasContent()) {
+      List<Backup> content = backups.getContent();
+      nextIdAfter = content.get(content.size() - 1).getId();
+      nextCursor = Base64.getEncoder().encodeToString(nextIdAfter.toString().getBytes());
+    }
+
+    return new CursorPageResponseBackupDto(
+        backups.map(backupMapper::toDto),
+        nextCursor,
+        nextIdAfter,
+        backups.getSize(),
+        backups.getTotalElements(),
+        backups.hasNext()
+    );  }
 
   public BackupDto findLatest() {
     Backup lastBackup = backupRepository.findFirstByOrderByStartedAtDesc()
@@ -39,5 +69,66 @@ public class BackupService {
     return false;
   }
 
+  private Specification<Backup> getSpec(String worker, String status, Instant startedAtFrom,
+      Instant startedAtTo, Long idAfter) {
+    Specification<Backup> spec = Specification.where(null);
+    if (worker != null && !worker.isEmpty()) {
+      spec = spec.and((root, query, cb) ->
+          cb.like(root.get("worker"), "%" + worker + "%"));
+    }
+    if (status != null && !status.isEmpty()) {
+      spec = spec.and((root, query, cb) ->
+          cb.equal(root.get("status"), status));
+    }
 
+    if (startedAtFrom != null && startedAtTo == null) {
+      spec = spec.and((root, query, cb) ->
+          cb.between(root.get("startTime"), startedAtFrom, Instant.now()));
+    } else if (startedAtFrom == null && startedAtTo != null) {
+      spec = spec.and((root, query, cb) ->
+          cb.between(root.get("startTime"), Instant.EPOCH, startedAtTo));
+    }
+    if (startedAtFrom != null && startedAtTo != null) {
+      spec = spec.and((root, query, cb) ->
+          cb.between(root.get("startTime"), startedAtFrom, startedAtTo));
+    }
+
+    if (idAfter != null) {
+      spec = spec.and((root, query, criteriaBuilder) ->
+          criteriaBuilder.greaterThan(root.get("id"), idAfter));
+    }
+
+    return spec;
+  }
+
+  private Pageable createPageable(Integer size, String sortField, String sortDirection) {
+    if (size == null || size <= 0) {
+      size = 10;
+    }
+
+    Sort sort;
+    if (sortField != null && !sortField.isEmpty()) {
+      if ("desc".equalsIgnoreCase(sortDirection)) {
+        sort = Sort.by(Sort.Direction.DESC, sortField);
+      } else {
+        sort = Sort.by(Sort.Direction.ASC, sortField);
+      }
+    } else {
+      sort = Sort.by(Direction.DESC, "startedAt");
+    }
+
+    return PageRequest.of(0, size, sort);
+  }
+
+  private Long decodeCursor(String cursor) {
+    if (cursor != null) {
+      try {
+        String decoded = new String(Base64.getDecoder().decode(cursor));
+        return Long.parseLong(decoded);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid cursor format");
+      }
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/practice/hrbank/util/CursorPaginationUtils.java
+++ b/src/main/java/com/practice/hrbank/util/CursorPaginationUtils.java
@@ -1,0 +1,51 @@
+package com.practice.hrbank.util;
+
+import java.util.Base64;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+public class CursorPaginationUtils {
+
+  private CursorPaginationUtils() {
+  }
+
+  public static Pageable createPageable(Integer size, String sortField, String sortDirection,
+      String defaultSortField, String defaultSortDirection) {
+    if (size == null || size <= 0) {
+      size = 10;
+    }
+
+    Sort sort;
+    Direction direction;
+    if (sortField != null && !sortField.isEmpty()) {
+      direction = "desc".equalsIgnoreCase(sortDirection) ? Sort.Direction.DESC : Sort.Direction.ASC;
+      sort = Sort.by(direction, sortField);
+    } else {
+      direction = "desc".equalsIgnoreCase(defaultSortDirection) ? Sort.Direction.DESC : Sort.Direction.ASC;
+      sort = Sort.by(direction, defaultSortField);
+    }
+
+    return PageRequest.of(0, size, sort);
+  }
+
+  public static String encodeCursor(Long cursor) {
+    if (cursor != null) {
+      return Base64.getEncoder().encodeToString(cursor.toString().getBytes());
+    }
+    return null;
+  }
+
+  public static Long decodeCursor(String cursor) {
+    if (cursor != null) {
+      try {
+        String decoded = new String(Base64.getDecoder().decode(cursor));
+        return Long.parseLong(decoded);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid cursor format");
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
## 주요 변경 사항
- 백업 이력 목록 조회 기능 구현
- 페이징, 정렬 기능 구현
- build.gradle에서 spring batch 의존성 제거

## 고민
- ~~페이징과 정렬은 목록 조회에서 공통으로 사용하니까 Util 클래스 만들어서 재사용하면 어떨까 얘기해보면 좋을 것 같습니다!~~
- `CursorPageUtils` 클래스의 `createPageable` 메서드에서 삼항연산자를 쓰는 게 나을지, if-else 문으로 쓰는 게 나을지 고민입니당..